### PR TITLE
[REA-44] Activity stream

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,7 @@ github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6D
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -312,6 +313,7 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
+golang.org/x/net v0.0.0-20190613194153-d28f0bde5980 h1:dfGZHvZk057jK2MCeWus/TowKpJ8y4AmooUzdBSR9GU=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -362,6 +364,7 @@ golang.org/x/sys v0.0.0-20200219091948-cb0a6d8edb6c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -43,6 +43,13 @@ func TestNewConfig(t *testing.T) {
 	require.Equal(t, 3*time.Second, config.Clustering.ReplicaFetchTimeout)
 	require.Equal(t, 1, config.Clustering.MinISR)
 
+	require.Equal(t, true, config.ActivityStream.Enabled)
+	require.Equal(t, time.Minute, config.ActivityStream.PublicationTimeout)
+	require.Equal(t, "leader", config.ActivityStream.PublicationAckPolicy)
+	require.Equal(t, "foo", config.ActivityStream.Group)
+	require.Equal(t, int32(2), config.ActivityStream.ReplicationFactor)
+	require.Equal(t, int32(3), config.ActivityStream.Partitions)
+
 	require.Equal(t, []string{"nats://localhost:4222"}, config.NATS.Servers)
 }
 

--- a/server/configs/full.conf
+++ b/server/configs/full.conf
@@ -33,6 +33,15 @@ clustering {
     min.insync.replicas: 1
 }
 
+activity.stream {
+    enabled: true
+    publication.timeout: "1m"
+    publication.ack.policy: "leader"
+    group: "foo"
+    replication.factor: 2
+    partitions: 3
+}
+
 nats {
     servers: [nats://localhost:4222]
 }

--- a/server/metadata.go
+++ b/server/metadata.go
@@ -333,6 +333,15 @@ func (m *metadataAPI) CreatePartition(ctx context.Context, req *proto.CreatePart
 	// Wait for leader to create partition (best effort).
 	m.waitForPartitionLeader(ctx, req.Partition.Stream, leader, req.Partition.Id)
 
+	err := m.Server.publishActivityEvent(client.ActivityStreamEvent{
+		Op:        client.ActivityOp_CREATE_PARTITION,
+		Stream:    req.Partition.Stream,
+		Partition: req.Partition.Id,
+	})
+	if err != nil {
+		return status.Newf(codes.Internal, "Failed to publish on the activity stream: %v", err.Error())
+	}
+
 	return nil
 }
 
@@ -373,6 +382,14 @@ func (m *metadataAPI) DeleteStream(ctx context.Context, req *proto.DeleteStreamO
 			code = codes.NotFound
 		}
 		return status.New(code, err.Error())
+	}
+
+	err := m.Server.publishActivityEvent(client.ActivityStreamEvent{
+		Op:     client.ActivityOp_DELETE_STREAM,
+		Stream: req.Stream,
+	})
+	if err != nil {
+		return status.Newf(codes.Internal, "Failed to publish on the activity stream: %v", err.Error())
 	}
 
 	return nil

--- a/server/server.go
+++ b/server/server.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
+	lift "github.com/liftbridge-io/go-liftbridge"
 	client "github.com/liftbridge-io/liftbridge-api/go"
 	"github.com/liftbridge-io/liftbridge/server/health"
 	"github.com/liftbridge-io/liftbridge/server/logger"
@@ -30,29 +31,41 @@ import (
 
 const stateFile = "liftbridge"
 
+const (
+	streamsSubject     = "streams"
+	activitySubject    = "activity"
+	activityStream     = activitySubject + "_stream"
+	raftSubject        = "raft"
+	replicationSubject = "replication"
+	acksSubject        = "acks"
+	publishesSubject   = "publishes"
+)
+
 // Server is the main Liftbridge object. Create it by calling New or
 // RunServerWithConfig.
 type Server struct {
-	config             *Config
-	listener           net.Listener
-	nc                 *nats.Conn
-	ncRaft             *nats.Conn
-	ncRepl             *nats.Conn
-	ncAcks             *nats.Conn
-	ncPublishes        *nats.Conn
-	logger             logger.Logger
-	loggerOut          io.Writer
-	api                *grpc.Server
-	metadata           *metadataAPI
-	shutdownCh         chan struct{}
-	raft               atomic.Value
-	leaderSub          *nats.Subscription
-	recoveryStarted    bool
-	latestRecoveredLog *raft.Log
-	mu                 sync.RWMutex
-	shutdown           bool
-	running            bool
-	goroutineWait      sync.WaitGroup
+	config               *Config
+	listener             net.Listener
+	port                 int
+	nc                   *nats.Conn
+	ncRaft               *nats.Conn
+	ncRepl               *nats.Conn
+	ncAcks               *nats.Conn
+	ncPublishes          *nats.Conn
+	logger               logger.Logger
+	loggerOut            io.Writer
+	api                  *grpc.Server
+	metadata             *metadataAPI
+	shutdownCh           chan struct{}
+	raft                 atomic.Value
+	leaderSub            *nats.Subscription
+	recoveryStarted      bool
+	latestRecoveredLog   *raft.Log
+	mu                   sync.RWMutex
+	shutdown             bool
+	running              bool
+	goroutineWait        sync.WaitGroup
+	activityStreamClient lift.Client
 }
 
 // RunServerWithConfig creates and starts a new Server with the given
@@ -126,12 +139,13 @@ func (s *Server) Start() (err error) {
 		return errors.Wrap(err, "failed starting listener")
 	}
 	s.listener = l
+	s.port = l.Addr().(*net.TCPAddr).Port
 
 	s.logger.Infof("Server ID:        %s", s.config.Clustering.ServerID)
 	s.logger.Infof("Namespace:        %s", s.config.Clustering.Namespace)
 	s.logger.Infof("Retention Policy: %s", s.config.Log.RetentionString())
 	s.logger.Infof("Starting server on %s...",
-		net.JoinHostPort(listenAddress.Host, strconv.Itoa(l.Addr().(*net.TCPAddr).Port)))
+		net.JoinHostPort(listenAddress.Host, strconv.Itoa(s.port)))
 
 	// Set a lower bound of one second for LogRollTime to avoid frequent log
 	// rolls which will cause performance problems. This is mainly here because
@@ -200,6 +214,10 @@ func (s *Server) Stop() error {
 		}
 	}
 
+	if s.activityStreamClient != nil {
+		s.activityStreamClient.Close()
+	}
+
 	s.closeNATSConns()
 	s.running = false
 	s.shutdown = true
@@ -255,39 +273,40 @@ func (s *Server) recoverAndPersistState() error {
 // publishes.
 func (s *Server) createNATSConns() error {
 	// NATS connection used for stream data.
-	nc, err := s.createNATSConn("streams")
+	nc, err := s.createNATSConn(streamsSubject)
 	if err != nil {
 		return err
 	}
 	s.nc = nc
 
 	// NATS connection used for Raft metadata replication.
-	ncr, err := s.createNATSConn("raft")
+	ncr, err := s.createNATSConn(raftSubject)
 	if err != nil {
 		return err
 	}
 	s.ncRaft = ncr
 
 	// NATS connection used for stream replication.
-	ncRepl, err := s.createNATSConn("replication")
+	ncRepl, err := s.createNATSConn(replicationSubject)
 	if err != nil {
 		return err
 	}
 	s.ncRepl = ncRepl
 
 	// NATS connection used for sending acks.
-	ncAcks, err := s.createNATSConn("acks")
+	ncAcks, err := s.createNATSConn(acksSubject)
 	if err != nil {
 		return err
 	}
 	s.ncAcks = ncAcks
 
 	// NATS connection used for publishing messages.
-	ncPublishes, err := s.createNATSConn("publishes")
+	ncPublishes, err := s.createNATSConn(publishesSubject)
 	if err != nil {
 		return err
 	}
 	s.ncPublishes = ncPublishes
+
 	return nil
 }
 
@@ -438,8 +457,12 @@ func (s *Server) startMetadataRaft() error {
 							// Node lost leadership, continue loop.
 							continue
 						default:
-							// TODO: probably step down as leader?
-							panic(err)
+							// Step down as leader.
+							s.logger.Warn("Stepping down as metadata leader")
+							if future := node.LeadershipTransfer(); future.Error() != nil {
+								panic(errors.Wrap(future.Error(), "error on metadata leadership step down"))
+							}
+							continue
 						}
 					}
 				} else {
@@ -470,6 +493,41 @@ func (s *Server) getRaft() *raftNode {
 	return r.(*raftNode)
 }
 
+// createActivityStream creates the activity stream and connects a local client
+// that will be subscribed to it.
+func (s *Server) createActivityStream() error {
+	if !s.config.ActivityStream.Enabled {
+		return nil
+	}
+
+	// Connect a local client that will be used to publish on the activity
+	// stream
+	listenAddress := s.config.GetListenAddress()
+	addrs := []string{listenAddress.Host + ":" + strconv.Itoa(s.port)}
+	var err error
+	s.activityStreamClient, err = lift.Connect(addrs)
+	if err != nil {
+		return errors.Wrap(err, "failed to connect the activity stream client")
+	}
+
+	options := []lift.StreamOption{
+		lift.Group(s.config.ActivityStream.Group),
+		lift.ReplicationFactor(s.config.ActivityStream.ReplicationFactor),
+		lift.Partitions(s.config.ActivityStream.Partitions),
+	}
+
+	err = s.activityStreamClient.CreateStream(context.Background(),
+		activitySubject,
+		activityStream,
+		options...,
+	)
+	if err != nil && err != lift.ErrStreamExists {
+		return errors.Wrap(err, "failed to create an activity stream")
+	}
+
+	return nil
+}
+
 // leadershipAcquired should be called when this node is elected leader.
 func (s *Server) leadershipAcquired() error {
 	s.logger.Infof("Server became metadata leader, performing leader promotion actions")
@@ -487,7 +545,7 @@ func (s *Server) leadershipAcquired() error {
 	s.leaderSub = sub
 
 	atomic.StoreInt64(&(s.getRaft().leader), 1)
-	return nil
+
 }
 
 // leadershipLost should be called when this node loses leadership.
@@ -504,6 +562,13 @@ func (s *Server) leadershipLost() error {
 
 	s.metadata.LostLeadership()
 	atomic.StoreInt64(&(s.getRaft().leader), 0)
+
+	// Close any activity stream client
+	if s.activityStreamClient != nil {
+		s.activityStreamClient.Close()
+		s.activityStreamClient = nil
+	}
+
 	return nil
 }
 
@@ -768,4 +833,42 @@ func (s *Server) startGoroutine(f func()) {
 		f()
 		s.goroutineWait.Done()
 	}()
+}
+
+// publishActivityEvent publishes an event on the activity stream.
+func (s *Server) publishActivityEvent(streamEvent client.ActivityStreamEvent) error {
+	if !s.config.ActivityStream.Enabled {
+		return nil
+	}
+
+	data, err := streamEvent.Marshal()
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal a stream event")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), s.config.ActivityStream.PublicationTimeout)
+	defer cancel()
+
+	var messageOption lift.MessageOption
+	switch s.config.ActivityStream.PublicationAckPolicy {
+	case "none":
+	case "leader":
+		messageOption = lift.AckPolicyLeader()
+	case "all":
+		messageOption = lift.AckPolicyAll()
+	default:
+		return fmt.Errorf("Unknown activity stream publication ack policy %q", s.config.ActivityStream.PublicationAckPolicy)
+	}
+
+	_, err = s.activityStreamClient.Publish(
+		ctx,
+		activityStream,
+		data,
+		messageOption,
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to publish a stream event")
+	}
+
+	return nil
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	lift "github.com/liftbridge-io/go-liftbridge"
+	liftApi "github.com/liftbridge-io/liftbridge-api/go"
 	natsdTest "github.com/nats-io/nats-server/v2/test"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -1319,4 +1320,52 @@ func TestPropagatedShrinkExpandISR(t *testing.T) {
 
 	// Wait for ISR to expand.
 	waitForISR(t, 10*time.Second, name, 0, 2, s1, s2)
+}
+
+// Ensure activity stream partition creation event occurs
+func TestActivityStreamCreatePartition(t *testing.T) {
+	defer cleanupStorage(t)
+
+	// Use a central NATS server.
+	ns := natsdTest.RunDefaultServer()
+	defer ns.Shutdown()
+
+	// Configure server.
+	s1Config := getTestConfig("a", true, 5050)
+	s1Config.ActivityStream.Enabled = true
+	s1Config.ActivityStream.PublicationTimeout = time.Second
+	s1Config.ActivityStream.PublicationAckPolicy = "leader"
+	s1 := runServerWithConfig(t, s1Config)
+	defer s1.Stop()
+
+	// Wait for server to elect itself leader.
+	getMetadataLeader(t, 10*time.Second, s1)
+
+	client, err := lift.Connect([]string{"localhost:5050"})
+	require.NoError(t, err)
+	defer client.Close()
+
+	// The first message read back should be the creation of the activity stream
+	// partition.
+	msgs := make(chan lift.Message, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	err = client.Subscribe(ctx, activityStream, func(msg lift.Message, err error) {
+		require.NoError(t, err)
+		msgs <- msg
+		cancel()
+	}, lift.StartAtEarliestReceived())
+	require.NoError(t, err)
+
+	// Wait to get the new message.
+	select {
+	case msg := <-msgs:
+		var se liftApi.ActivityStreamEvent
+		err = se.Unmarshal(msg.Value())
+		require.NoError(t, err)
+		require.Equal(t, liftApi.ActivityOp_CREATE_PARTITION, se.GetOp())
+		require.Equal(t, activityStream, se.GetStream())
+		require.Equal(t, int32(0), se.GetPartition())
+	case <-time.After(5 * time.Second):
+		t.Fatal("Did not receive expected message")
+	}
 }


### PR DESCRIPTION
This PR introduces an “activity stream” that records and persists partition creation and stream deletion events.

## Context

The background to this work is that we want to manage a collection of consumers that process events arising across a large collection of streams. The set of streams is dynamic - that is, streams will be programmatically created and destroyed frequently - and many of them will also be sparsely used; they will undergo periods where there are many messages, and periods when they are idle. Typically, the set of streams that is active at any given time will be a small fraction of the total number of streams.

The idea of this PR is that a stream exists that carries meta-events for a Liftbridge cluster. The meta-events supported in this PR are stream creation and deletion events, but in a later PR we also propose to include pause and resume events, assuming we can support that functionality. One or more consumers can subscribe to events in the meta-event stream and can thereby manage the process of consuming and processing messages on the regular streams as they come and go.

In this PR the meta-event stream is termed the Activity Stream. It is disabled by default and can be activated using the Liftbridge configuration.

## Implementation

The implementation proposed in this PR uses a local Liftbridge connection created on the metadata leader when elected. The activity stream in also created at this point. The events we are interested in are then recorded (pushed) into the stream. External clients can then subscribe to this stream to get a list of all past events as well as a notification when new events occur.

## Limitations / questions

The present implementation has some limitations that we would like to discuss, principally concerning the possibility that publication to the activity stream can fail. Considering the pair of events - publication of the meta-event message and the occurrence of the meta-event itself - we wonder if that pair of events can or should occur atomically or not.

In the present code, publication to the activity stream just occurs after the completion of the meta event itself (ie stream creation or deletion). If that operation fails, then the triggering request returns an error response, even though the underlying operation in fact succeeded. This doesn't serve well the requirements either of the client that triggered the operation, or the consumer of the activity stream.

To resolve this we either attempt to make the publication and the underlying operation atomic, or we say that the underlying operation is the thing that matters and the effect of that operation continues to be the source of truth. With this approach we would publish an event on the activity stream before attempting the underlying operation. Any recipient of that event would then be obliged to verify that the corresponding underlying event had in fact successfully followed by checking for the existence of the stream. Blocking operations could be provided that deal with the potential race conditions that then arise: for example, receive the stream created meta-event, and then block (with a context and timeout) for the stream itself to be created and for its leader selection to be completed). Similarly, when receiving a stream deletion meta-event, a client could check for existence of the (expected-to-be-deleted) stream and, if it still exists, block (with a context and timeout) for the error signifying deletion of the stream.