### PR TITLE
Add a timestamp to publication acks

### DIFF
--- a/server/commitlog/commitlog_test.go
+++ b/server/commitlog/commitlog_test.go
@@ -30,7 +30,7 @@ func TestNewCommitLog(t *testing.T) {
 	defer l.Close()
 	defer cleanup()
 
-	_, err = l.Append(msgs)
+	_, _, err = l.Append(msgs)
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -63,7 +63,7 @@ func TestAppendMessageSet(t *testing.T) {
 	set, _, err := newMessageSetFromProto(0, 0, msgs)
 	require.NoError(t, err)
 
-	offsets, err := l.AppendMessageSet(set)
+	offsets, _, err := l.AppendMessageSet(set)
 	require.NoError(t, err)
 	require.Equal(t, []int64{0, 1, 2, 3, 4}, offsets)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -100,7 +100,7 @@ func TestCommitLogRecover(t *testing.T) {
 				msgs[i] = &Message{Value: []byte(strconv.Itoa(i))}
 			}
 			for _, msg := range msgs {
-				_, err := l.Append([]*Message{msg})
+				_, _, err := l.Append([]*Message{msg})
 				require.NoError(t, err)
 			}
 
@@ -178,7 +178,7 @@ func BenchmarkCommitLog(b *testing.B) {
 	defer cleanup()
 
 	for i := 0; i < b.N; i++ {
-		_, err = l.Append(msgs)
+		_, _, err = l.Append(msgs)
 		require.NoError(b, err)
 	}
 }
@@ -198,7 +198,7 @@ func TestOffsets(t *testing.T) {
 	for i := 0; i < numMsgs; i++ {
 		msgs[i] = &Message{Value: []byte(strconv.Itoa(i))}
 	}
-	_, err := l.Append(msgs)
+	_, _, err := l.Append(msgs)
 	require.NoError(t, err)
 
 	require.Equal(t, int64(0), l.OldestOffset())
@@ -220,12 +220,12 @@ func TestCleaner(t *testing.T) {
 	defer l.Close()
 	defer cleanup()
 
-	_, err := l.Append(msgs)
+	_, _, err := l.Append(msgs)
 	require.NoError(t, err)
 	segments := l.Segments()
 	require.Equal(t, 1, len(l.Segments()))
 
-	_, err = l.Append(msgs)
+	_, _, err = l.Append(msgs)
 	require.NoError(t, err)
 
 	require.NoError(t, l.Clean())
@@ -252,7 +252,7 @@ func TestCleanerDeleteLeaderEpochOffsets(t *testing.T) {
 
 	// Add some messages.
 	for i := 0; i < 5; i++ {
-		_, err := l.Append([]*Message{{
+		_, _, err := l.Append([]*Message{{
 			Value:       []byte(strconv.Itoa(i)),
 			Timestamp:   time.Now().UnixNano(),
 			LeaderEpoch: 1,
@@ -261,7 +261,7 @@ func TestCleanerDeleteLeaderEpochOffsets(t *testing.T) {
 	}
 
 	for i := 0; i < 5; i++ {
-		_, err := l.Append([]*Message{{
+		_, _, err := l.Append([]*Message{{
 			Value:       []byte(strconv.Itoa(i + 5)),
 			Timestamp:   time.Now().UnixNano(),
 			LeaderEpoch: 2,
@@ -270,7 +270,7 @@ func TestCleanerDeleteLeaderEpochOffsets(t *testing.T) {
 	}
 
 	for i := 0; i < 5; i++ {
-		_, err := l.Append([]*Message{{
+		_, _, err := l.Append([]*Message{{
 			Value:       []byte(strconv.Itoa(i + 10)),
 			Timestamp:   time.Now().UnixNano(),
 			LeaderEpoch: 3,
@@ -317,7 +317,7 @@ func TestCleanerReplaceLeaderEpochOffsets(t *testing.T) {
 
 	// Add some messages.
 	for i := 0; i < 5; i++ {
-		_, err := l.Append([]*Message{{
+		_, _, err := l.Append([]*Message{{
 			Key:         []byte("foo"),
 			Value:       []byte(strconv.Itoa(i)),
 			Timestamp:   time.Now().UnixNano(),
@@ -327,7 +327,7 @@ func TestCleanerReplaceLeaderEpochOffsets(t *testing.T) {
 	}
 
 	for i := 0; i < 5; i++ {
-		_, err := l.Append([]*Message{{
+		_, _, err := l.Append([]*Message{{
 			Key:         []byte("bar"),
 			Value:       []byte(strconv.Itoa(i + 5)),
 			Timestamp:   time.Now().UnixNano(),
@@ -337,7 +337,7 @@ func TestCleanerReplaceLeaderEpochOffsets(t *testing.T) {
 	}
 
 	for i := 0; i < 5; i++ {
-		_, err := l.Append([]*Message{{
+		_, _, err := l.Append([]*Message{{
 			Key:         []byte("baz"),
 			Value:       []byte(strconv.Itoa(i + 10)),
 			Timestamp:   time.Now().UnixNano(),
@@ -389,7 +389,7 @@ func TestOffsetForTimestamp(t *testing.T) {
 		msgs[i] = &Message{Value: []byte(strconv.Itoa(i)), Timestamp: int64(i * 10)}
 	}
 	for _, msg := range msgs {
-		_, err := l.Append([]*Message{msg})
+		_, _, err := l.Append([]*Message{msg})
 		require.NoError(t, err)
 	}
 
@@ -437,7 +437,7 @@ func TestTruncate(t *testing.T) {
 
 	// Add some messages.
 	for i := 0; i < 5; i++ {
-		_, err := l.Append([]*Message{{
+		_, _, err := l.Append([]*Message{{
 			Value:       []byte(strconv.Itoa(i)),
 			Timestamp:   time.Now().UnixNano(),
 			LeaderEpoch: 1,
@@ -446,7 +446,7 @@ func TestTruncate(t *testing.T) {
 	}
 
 	for i := 0; i < 5; i++ {
-		_, err := l.Append([]*Message{{
+		_, _, err := l.Append([]*Message{{
 			Value:       []byte(strconv.Itoa(i + 5)),
 			Timestamp:   time.Now().UnixNano(),
 			LeaderEpoch: 2,
@@ -455,7 +455,7 @@ func TestTruncate(t *testing.T) {
 	}
 
 	for i := 0; i < 5; i++ {
-		_, err := l.Append([]*Message{{
+		_, _, err := l.Append([]*Message{{
 			Value:       []byte(strconv.Itoa(i + 10)),
 			Timestamp:   time.Now().UnixNano(),
 			LeaderEpoch: 3,
@@ -489,7 +489,7 @@ func TestNotifyLEOMismatch(t *testing.T) {
 
 	// Add some messages.
 	for i := 0; i < 5; i++ {
-		_, err := l.Append([]*Message{{
+		_, _, err := l.Append([]*Message{{
 			Value:       []byte(strconv.Itoa(i)),
 			Timestamp:   time.Now().UnixNano(),
 			LeaderEpoch: 1,
@@ -499,7 +499,7 @@ func TestNotifyLEOMismatch(t *testing.T) {
 
 	// Get current log end offset and then add another message.
 	leo := l.NewestOffset()
-	_, err := l.Append([]*Message{{
+	_, _, err := l.Append([]*Message{{
 		Value:       []byte(strconv.Itoa(5)),
 		Timestamp:   time.Now().UnixNano(),
 		LeaderEpoch: 1,
@@ -529,7 +529,7 @@ func TestNotifyLEONewData(t *testing.T) {
 
 	// Add some messages.
 	for i := 0; i < 5; i++ {
-		_, err := l.Append([]*Message{{
+		_, _, err := l.Append([]*Message{{
 			Value:       []byte(strconv.Itoa(i)),
 			Timestamp:   time.Now().UnixNano(),
 			LeaderEpoch: 1,
@@ -551,7 +551,7 @@ func TestNotifyLEONewData(t *testing.T) {
 	}
 
 	// Add another message.
-	_, err := l.Append([]*Message{{
+	_, _, err := l.Append([]*Message{{
 		Value:       []byte(strconv.Itoa(5)),
 		Timestamp:   time.Now().UnixNano(),
 		LeaderEpoch: 1,

--- a/server/commitlog/compact_cleaner_test.go
+++ b/server/commitlog/compact_cleaner_test.go
@@ -284,7 +284,7 @@ func benchmarkClean(b *testing.B, segmentSize int64) {
 						Key:   []byte(keys[rand.Intn(len(keys))]),
 						Value: buf,
 					}
-					offsets, err := l.Append([]*Message{msg})
+					offsets, _, err := l.Append([]*Message{msg})
 					require.NoError(b, err)
 					l.SetHighWatermark(offsets[len(offsets)-1])
 				}
@@ -303,7 +303,7 @@ func appendToLog(t *testing.T, l *commitLog, entries []keyValue, commit bool) {
 			Key:   entry.key,
 			Value: entry.value,
 		}
-		offsets, err := l.Append([]*Message{msg})
+		offsets, _, err := l.Append([]*Message{msg})
 		require.NoError(t, err)
 		if commit {
 			l.SetHighWatermark(offsets[len(offsets)-1])

--- a/server/commitlog/interface.go
+++ b/server/commitlog/interface.go
@@ -50,12 +50,12 @@ type CommitLog interface {
 	LastLeaderEpoch() uint64
 
 	// Append writes the given batch of messages to the log and returns their
-	// corresponding offsets in the log.
-	Append(msg []*Message) ([]int64, error)
+	// corresponding offsets and timestamps in the log.
+	Append(msg []*Message) ([]int64, []int64, error)
 
 	// AppendMessageSet writes the given message set data to the log and
-	// returns the corresponding offsets in the log.
-	AppendMessageSet(ms []byte) ([]int64, error)
+	// returns the corresponding offsets and timestamps in the log.
+	AppendMessageSet(ms []byte) ([]int64, []int64, error)
 
 	// Clean applies retention and compaction rules against the log, if
 	// applicable.

--- a/server/commitlog/reader_test.go
+++ b/server/commitlog/reader_test.go
@@ -41,7 +41,7 @@ func TestReaderUncommittedStartOffset(t *testing.T) {
 					LeaderEpoch: 42,
 				}
 			}
-			_, err = l.Append(msgs)
+			_, _, err = l.Append(msgs)
 			require.NoError(t, err)
 			idx := 4
 			ctx, cancel := context.WithCancel(context.Background())
@@ -69,7 +69,7 @@ func TestReaderUncommittedBlockCancel(t *testing.T) {
 	defer cleanup()
 
 	msg := &Message{Value: []byte("hi")}
-	_, err := l.Append([]*Message{msg})
+	_, _, err := l.Append([]*Message{msg})
 	require.NoError(t, err)
 
 	r, err := l.NewReader(0, true)
@@ -98,7 +98,7 @@ func TestReaderUncommittedBlockForSegmentWrite(t *testing.T) {
 		Timestamp:   1,
 		LeaderEpoch: 42,
 	}
-	_, err := l.Append([]*Message{msg})
+	_, _, err := l.Append([]*Message{msg})
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -123,7 +123,7 @@ func TestReaderUncommittedBlockForSegmentWrite(t *testing.T) {
 
 	go func() {
 		time.Sleep(5 * time.Millisecond)
-		_, err := l.Append([]*Message{msg})
+		_, _, err := l.Append([]*Message{msg})
 		require.NoError(t, err)
 		close(done)
 	}()
@@ -146,7 +146,7 @@ func TestReaderUncommittedReadError(t *testing.T) {
 	defer cleanup()
 
 	msg := &Message{Value: []byte("hi")}
-	_, err := l.Append([]*Message{msg})
+	_, _, err := l.Append([]*Message{msg})
 	require.NoError(t, err)
 
 	r, err := l.NewReader(0, true)
@@ -179,7 +179,7 @@ func TestReaderCommittedStartOffset(t *testing.T) {
 					LeaderEpoch: 42,
 				}
 			}
-			_, err = l.Append(msgs)
+			_, _, err = l.Append(msgs)
 			require.NoError(t, err)
 			l.SetHighWatermark(4)
 			idx := 2
@@ -222,10 +222,10 @@ func TestReaderCommittedReadError(t *testing.T) {
 	defer cleanup()
 
 	msg := &Message{Value: []byte("hi")}
-	_, err := l.Append([]*Message{msg})
+	_, _, err := l.Append([]*Message{msg})
 	require.NoError(t, err)
 	msg = &Message{Value: []byte("hi")}
-	_, err = l.Append([]*Message{msg})
+	_, _, err = l.Append([]*Message{msg})
 	require.NoError(t, err)
 	l.SetHighWatermark(0)
 
@@ -258,7 +258,7 @@ func TestReaderCommittedWaitOnEmptyLog(t *testing.T) {
 
 	go func() {
 		time.Sleep(5 * time.Millisecond)
-		_, err := l.Append([]*Message{msg})
+		_, _, err := l.Append([]*Message{msg})
 		require.NoError(t, err)
 		l.SetHighWatermark(0)
 	}()
@@ -292,7 +292,7 @@ func TestReaderCommittedRead(t *testing.T) {
 					LeaderEpoch: 42,
 				}
 			}
-			_, err = l.Append(msgs)
+			_, _, err = l.Append(msgs)
 			require.NoError(t, err)
 			l.SetHighWatermark(9)
 			r, err := l.NewReader(0, false)
@@ -331,7 +331,7 @@ func TestReaderCommittedReadToHW(t *testing.T) {
 					LeaderEpoch: 42,
 				}
 			}
-			_, err = l.Append(msgs)
+			_, _, err = l.Append(msgs)
 			require.NoError(t, err)
 			l.SetHighWatermark(4)
 			r, err := l.NewReader(0, false)
@@ -368,7 +368,7 @@ func TestReaderCommittedWaitForHW(t *testing.T) {
 			LeaderEpoch: 42,
 		}
 	}
-	_, err = l.Append(msgs)
+	_, _, err = l.Append(msgs)
 	require.NoError(t, err)
 	l.SetHighWatermark(4)
 	r, err := l.NewReader(0, false)
@@ -408,7 +408,7 @@ func TestReaderCommittedCancel(t *testing.T) {
 			LeaderEpoch: 42,
 		}
 	}
-	_, err = l.Append(msgs)
+	_, _, err = l.Append(msgs)
 	require.NoError(t, err)
 	l.SetHighWatermark(4)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -452,14 +452,14 @@ func TestReaderCommittedCapOffset(t *testing.T) {
 		Timestamp:   1,
 		LeaderEpoch: 42,
 	}
-	_, err := l.Append([]*Message{msg1})
+	_, _, err := l.Append([]*Message{msg1})
 	require.NoError(t, err)
 	msg2 := &Message{
 		Value:       []byte("hi"),
 		Timestamp:   2,
 		LeaderEpoch: 42,
 	}
-	_, err = l.Append([]*Message{msg2})
+	_, _, err = l.Append([]*Message{msg2})
 	require.NoError(t, err)
 	l.SetHighWatermark(0)
 

--- a/server/partition.go
+++ b/server/partition.go
@@ -592,7 +592,7 @@ func (p *partition) handleReplicationResponse(msg *nats.Msg) int {
 	if offset < p.log.NewestOffset()+1 {
 		return 0
 	}
-	offsets, err := p.log.AppendMessageSet(data)
+	offsets, _, err := p.log.AppendMessageSet(data)
 	if err != nil {
 		panic(fmt.Errorf("Failed to replicate data to log %s: %v", p, err))
 	}
@@ -711,14 +711,14 @@ func (p *partition) messageProcessingLoop(recvChan <-chan *nats.Msg, stop <-chan
 		}
 
 		// Write uncommitted messages to log.
-		offsets, err := p.log.Append(msgBatch)
+		offsets, timestamps, err := p.log.Append(msgBatch)
 		if err != nil {
 			p.srv.logger.Errorf("Failed to append to log %s: %v", p, err)
 			continue
 		}
 
 		for i, msg := range msgBatch {
-			p.processPendingMessage(offsets[i], msg)
+			p.processPendingMessage(offsets[i], timestamps[i], msg)
 		}
 
 		// Update this replica's latest offset.
@@ -732,7 +732,7 @@ func (p *partition) messageProcessingLoop(recvChan <-chan *nats.Msg, stop <-chan
 // processPendingMessage sends an ack if the message's AckPolicy is LEADER and
 // adds the pending message to the commit queue. Messages are removed from the
 // queue and committed when the entire ISR has replicated them.
-func (p *partition) processPendingMessage(offset int64, msg *commitlog.Message) {
+func (p *partition) processPendingMessage(offset, timestamp int64, msg *commitlog.Message) {
 	ack := &client.Ack{
 		Stream:           p.Stream,
 		PartitionSubject: p.Subject,
@@ -741,6 +741,7 @@ func (p *partition) processPendingMessage(offset int64, msg *commitlog.Message) 
 		AckInbox:         msg.AckInbox,
 		CorrelationId:    msg.CorrelationID,
 		AckPolicy:        msg.AckPolicy,
+		Timestamp:        timestamp,
 	}
 	if msg.AckPolicy == client.AckPolicy_LEADER {
 		// Send the ack now since AckPolicy_LEADER means we ack as soon as the

--- a/server/protocol/envelope_test.go
+++ b/server/protocol/envelope_test.go
@@ -46,6 +46,7 @@ func TestMarshalUnmarshalAck(t *testing.T) {
 		AckInbox:         "ack",
 		CorrelationId:    "123",
 		PartitionSubject: "foo.1",
+		Timestamp:        43,
 	}
 
 	envelope, err := MarshalAck(ack)


### PR DESCRIPTION
Publication ACKs currently return the stream offset the message was committed to, but not its timestamp. This PR adds this.